### PR TITLE
Avoid lock during check

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # globaltrends v.0.0.12
 * Stop direct exports from functions to .GlobalEnv
-* Exports of objects (e.g., SQL connections, keyword tables) are redirected to package namespace.
+* Exports of objects (e.g., SQL connections, keyword tables) are redirected to package environment `gt.env`.
 
 # globaltrends v.0.0.11
 * Add function plot_map()

--- a/R/add_keywords.r
+++ b/R/add_keywords.r
@@ -148,52 +148,52 @@ add_object_keyword <- function(keyword, time = "2010-01-01 2020-12-31") {
   .check_length(time, 1)
   .check_input(time, "character")
   if (type == "control") {
-    if (nrow(.keywords_control) == 0) {
+    if (nrow(gt.env$.keywords_control) == 0) {
       new_batch <- 1
     } else {
-      new_batch <- max(.keywords_control$batch) + 1
+      new_batch <- max(gt.env$.keywords_control$batch) + 1
     }
     keyword <- str_squish(keyword)
     data <- tibble(batch = new_batch, keyword, type = "control")
-    dbWriteTable(conn = globaltrends_db, name = "batch_keywords", value = data, append = TRUE)
+    dbWriteTable(conn = gt.env$globaltrends_db, name = "batch_keywords", value = data, append = TRUE)
     data <- tibble(batch = new_batch, time = time, type = "control")
-    dbWriteTable(conn = globaltrends_db, name = "batch_time", value = data, append = TRUE)
-    keywords_control <- filter(.tbl_keywords, .data$type == "control")
+    dbWriteTable(conn = gt.env$globaltrends_db, name = "batch_time", value = data, append = TRUE)
+    keywords_control <- filter(gt.env$.tbl_keywords, .data$type == "control")
     keywords_control <- select(keywords_control, -.data$type)
     keywords_control <- collect(keywords_control)
     lst_export <- list(keywords_control, keywords_control)
     names(lst_export) <- list("keywords_control", ".keywords_control")
-    invisible(list2env(lst_export, envir = as.environment("package:globaltrends")))
-    time_control <- filter(.tbl_time, .data$type == "control")
+    invisible(list2env(lst_export, envir = gt.env))
+    time_control <- filter(gt.env$.tbl_time, .data$type == "control")
     time_control <- select(time_control, -.data$type)
     time_control <- collect(time_control)
     lst_export <- list(time_control, time_control)
     names(lst_export) <- list("time_control", ".time_control")
-    invisible(list2env(lst_export, envir = as.environment("package:globaltrends")))
+    invisible(list2env(lst_export, envir = gt.env))
     message(glue("Successfully created new control batch {new_batch} ({keyword_collapse}, {time}).", keyword_collapse = paste(keyword, collapse = ", ")))
     return(new_batch)
   } else if (type == "object") {
-    if (nrow(.keywords_object) == 0) {
+    if (nrow(gt.env$.keywords_object) == 0) {
       new_batch <- 1
     } else {
-      new_batch <- max(.keywords_object$batch) + 1
+      new_batch <- max(gt.env$.keywords_object$batch) + 1
     }
     data <- tibble(batch = new_batch, keyword, type = "object")
-    dbWriteTable(conn = globaltrends_db, name = "batch_keywords", value = data, append = TRUE)
+    dbWriteTable(conn = gt.env$globaltrends_db, name = "batch_keywords", value = data, append = TRUE)
     data <- tibble(batch = new_batch, time = time, type = "object")
-    dbWriteTable(conn = globaltrends_db, name = "batch_time", value = data, append = TRUE)
-    keywords_object <- filter(.tbl_keywords, .data$type == "object")
+    dbWriteTable(conn = gt.env$globaltrends_db, name = "batch_time", value = data, append = TRUE)
+    keywords_object <- filter(gt.env$.tbl_keywords, .data$type == "object")
     keywords_object <- select(keywords_object, -.data$type)
     keywords_object <- collect(keywords_object)
     lst_export <- list(keywords_object, keywords_object)
     names(lst_export) <- list("keywords_object", ".keywords_object")
-    invisible(list2env(lst_export, envir = as.environment("package:globaltrends")))
-    time_object <- filter(.tbl_time, .data$type == "object")
+    invisible(list2env(lst_export, envir = gt.env))
+    time_object <- filter(gt.env$.tbl_time, .data$type == "object")
     time_object <- select(time_object, -.data$type)
     time_object <- collect(time_object)
     lst_export <- list(time_object, time_object)
     names(lst_export) <- list("time_object", ".time_object")
-    invisible(list2env(lst_export, envir = as.environment("package:globaltrends")))
+    invisible(list2env(lst_export, envir = gt.env))
     message(glue("Successfully created new object batch {new_batch} ({keyword_collapse}, {time}).", keyword_collapse = paste(keyword, collapse = ", ")))
     return(new_batch)
   } else {
@@ -254,15 +254,15 @@ add_synonym.character <- function(keyword, synonym) {
     synonym <- str_squish(synonym)
     out <- tibble(keyword, synonym)
     dbWriteTable(
-      conn = globaltrends_db,
+      conn = gt.env$globaltrends_db,
       name = "keyword_synonyms",
       value = out,
       append = TRUE
     )
-    keyword_synonyms <- collect(.tbl_synonyms)
+    keyword_synonyms <- collect(gt.env$.tbl_synonyms)
     lst_export <- list(keyword_synonyms, keyword_synonyms)
     names(lst_export) <- list("keyword_synonyms", ".keyword_synonyms")
-    invisible(list2env(lst_export, envir = as.environment("package:globaltrends")))
+    invisible(list2env(lst_export, envir = gt.env))
     message(glue("Successfully added synonym | keyword: {keyword} | synonym: {synonym}"))
   }
 }

--- a/R/add_locations.r
+++ b/R/add_locations.r
@@ -20,10 +20,10 @@
 #' @param type Name of the location set that should be added. Object of type
 #' `character` of length 1.
 #' @param export Indicator whether the new location set should be directly
-#' exported to the package environment. Object of type `logical`, defaults to
-#' `TRUE`.
+#' exported to the package environment `gt.env`. Object of type `logical`,
+#' defaults to `TRUE`.
 #' @param db Connection to database file that should be closed. Defaults
-#' to `globaltrends_db`.
+#' to `gt.env$globaltrends_db`.
 #'
 #' @return
 #' Message that the location set has been created successfully. Location data is
@@ -46,7 +46,7 @@
 #' @importFrom stats na.omit
 #' @importFrom tibble tibble
 
-add_locations <- function(locations, type, export = TRUE, db = globaltrends_db) {
+add_locations <- function(locations, type, export = TRUE, db = gt.env$globaltrends_db) {
   .check_input(locations, "character")
   .check_input(type, "character")
   .check_length(type, 1)
@@ -69,18 +69,18 @@ add_locations <- function(locations, type, export = TRUE, db = globaltrends_db) 
   message(glue("Successfully created new location set {type} ({locations_collapse}).", locations_collapse = paste(locations, collapse = ", ")))
 }
 
-#' @title Export locations to globaltrends namespace
+#' @title Export locations to package environment gt.env
 #'
 #' @keywords internal
 #' @noRd
 
 .export_locations <- function() {
-  locations <- distinct(.tbl_locations, type)
+  locations <- distinct(gt.env$.tbl_locations, type)
   locations <- collect(locations)
   locations <- locations$type
 
   lst_locations <- map(locations, ~ {
-    out <- filter(.tbl_locations, .data$type == .x)
+    out <- filter(gt.env$.tbl_locations, .data$type == .x)
     out <- collect(out)
     out <- pull(out, .data$location)
     return(out)
@@ -88,5 +88,5 @@ add_locations <- function(locations, type, export = TRUE, db = globaltrends_db) 
 
   names(lst_locations) <- locations
 
-  invisible(list2env(lst_locations, envir = as.environment("package:globaltrends")))
+  invisible(list2env(lst_locations, envir = gt.env))
 }

--- a/R/compute_doi.r
+++ b/R/compute_doi.r
@@ -81,9 +81,9 @@ compute_doi.numeric <- function(object, control = 1, locations = "countries") {
   } else {
     walk(list(control, object), .check_batch)
     if (.test_empty(table = "data_doi", batch_c = control, batch_o = object, locations = locations)) {
-      data <- filter(.tbl_score, .data$batch_c == control & .data$batch_o == object)
+      data <- filter(gt.env$.tbl_score, .data$batch_c == control & .data$batch_o == object)
       data <- collect(data)
-      tmp_locations <- pull(collect(filter(.tbl_locations, .data$type == locations)), .data$location)
+      tmp_locations <- pull(collect(filter(gt.env$.tbl_locations, .data$type == locations)), .data$location)
       data <- filter(data, .data$location %in% tmp_locations & .data$synonym == 0)
 
       # compute doi measures
@@ -122,9 +122,9 @@ compute_doi.numeric <- function(object, control = 1, locations = "countries") {
         batch_o = object,
         locations = locations
       )
-      dbWriteTable(conn = globaltrends_db, name = "data_doi", value = out, append = TRUE)
+      dbWriteTable(conn = gt.env$globaltrends_db, name = "data_doi", value = out, append = TRUE)
     }
-    message(glue("Successfully computed DOI | control: {control} | object: {object} [{object}/{total}]", total = max(.keywords_object$batch)))
+    message(glue("Successfully computed DOI | control: {control} | object: {object} [{object}/{total}]", total = max(gt.env$.keywords_object$batch)))
   }
 }
 

--- a/R/compute_score.r
+++ b/R/compute_score.r
@@ -92,13 +92,13 @@
 #' @importFrom tidyr pivot_wider
 #' @importFrom tidyr unnest
 
-compute_score <- function(object, control = 1, locations = countries) UseMethod("compute_score", object)
+compute_score <- function(object, control = 1, locations = gt.env$countries) UseMethod("compute_score", object)
 
 #' @rdname compute_score
 #' @method compute_score numeric
 #' @export
 
-compute_score.numeric <- function(object, control = 1, locations = countries) {
+compute_score.numeric <- function(object, control = 1, locations = gt.env$countries) {
   control <- unlist(control)
   .check_length(control, 1)
   .check_input(locations, "character")
@@ -116,12 +116,12 @@ compute_score.numeric <- function(object, control = 1, locations = countries) {
         location = .x
       )) {
         qry_object <- filter(
-          .tbl_object,
+          gt.env$.tbl_object,
           .data$batch_c == control & .data$batch_o == object & .data$location == .x
         )
         qry_object <- collect(qry_object)
         if (nrow(qry_object) != 0) {
-          qry_control <- filter(.tbl_control, .data$batch == control & .data$location == .x)
+          qry_control <- filter(gt.env$.tbl_control, .data$batch == control & .data$location == .x)
           qry_control <- collect(qry_control)
 
           qry_control <- mutate(qry_control, date = as_date(.data$date))
@@ -254,12 +254,12 @@ compute_score.numeric <- function(object, control = 1, locations = countries) {
             batch_c = control,
             batch_o = object,
             synonym = case_when(
-              .data$keyword %in% .keyword_synonyms$synonym ~ TRUE,
+              .data$keyword %in% gt.env$.keyword_synonyms$synonym ~ TRUE,
               TRUE ~ FALSE
             )
           )
           dbWriteTable(
-            conn = globaltrends_db,
+            conn = gt.env$globaltrends_db,
             name = "data_score",
             value = out,
             append = TRUE
@@ -284,7 +284,7 @@ compute_score.numeric <- function(object, control = 1, locations = countries) {
 #' @method compute_score list
 #' @export
 
-compute_score.list <- function(object, control = 1, locations = countries) {
+compute_score.list <- function(object, control = 1, locations = gt.env$countries) {
   walk(object, compute_score, control = control, locations = locations)
 }
 
@@ -359,24 +359,24 @@ compute_voi <- function(object, control = 1) {
 #' @importFrom purrr walk
 
 .aggregate_synonym <- function(object) {
-  lst_synonym <- filter(.keywords_object, .data$batch == object)
-  lst_synonym1 <- inner_join(lst_synonym, .keyword_synonyms, by = "keyword")
-  lst_synonym2 <- inner_join(lst_synonym, .keyword_synonyms, by = c("keyword" = "synonym"))
+  lst_synonym <- filter(gt.env$.keywords_object, .data$batch == object)
+  lst_synonym1 <- inner_join(lst_synonym, gt.env$.keyword_synonyms, by = "keyword")
+  lst_synonym2 <- inner_join(lst_synonym, gt.env$.keyword_synonyms, by = c("keyword" = "synonym"))
   lst_synonym <- unique(c(lst_synonym1$synonym, lst_synonym2$keyword))
 
   if (length(lst_synonym) > 0) {
     message("Checking for synonyms...")
-    data_synonym <- filter(.tbl_score, .data$keyword %in% lst_synonym & .data$synonym == 1)
+    data_synonym <- filter(gt.env$.tbl_score, .data$keyword %in% lst_synonym & .data$synonym == 1)
     data_synonym <- collect(data_synonym)
 
     if (nrow(data_synonym) > 0) {
       message("Aggregating scores for synonyms...")
-      lst_main <- unique(.keyword_synonyms$keyword[.keyword_synonyms$synonym %in% lst_synonym])
-      data_main <- filter(.tbl_score, .data$keyword %in% lst_main)
+      lst_main <- unique(gt.env$.keyword_synonyms$keyword[gt.env$.keyword_synonyms$synonym %in% lst_synonym])
+      data_main <- filter(gt.env$.tbl_score, .data$keyword %in% lst_main)
       data_main <- collect(data_main)
 
       walk(lst_synonym, ~ {
-        keyword_main <- .keyword_synonyms$keyword[.keyword_synonyms$synonym == .x][[1]]
+        keyword_main <- gt.env$.keyword_synonyms$keyword[gt.env$.keyword_synonyms$synonym == .x][[1]]
         sub_main <- filter(data_main, .data$keyword == keyword_main)
 
         sub_synonym <- filter(data_synonym, .data$keyword == .x)
@@ -429,9 +429,9 @@ compute_voi <- function(object, control = 1) {
         )
 
         data <- bind_rows(sub_main, data_synonym_agg, data_synonym_nagg)
-        dbExecute(conn = globaltrends_db, statement = "DELETE FROM data_score WHERE keyword=?", params = list(keyword_main))
-        dbExecute(conn = globaltrends_db, statement = "DELETE FROM data_score WHERE keyword=?", params = list(.x))
-        dbWriteTable(conn = globaltrends_db, name = "data_score", value = data, append = TRUE)
+        dbExecute(conn = gt.env$globaltrends_db, statement = "DELETE FROM data_score WHERE keyword=?", params = list(keyword_main))
+        dbExecute(conn = gt.env$globaltrends_db, statement = "DELETE FROM data_score WHERE keyword=?", params = list(.x))
+        dbWriteTable(conn = gt.env$globaltrends_db, name = "data_score", value = data, append = TRUE)
       })
     }
   }

--- a/R/data.r
+++ b/R/data.r
@@ -6,7 +6,8 @@
 #' or object) and the id of the *batch* to which the keyword is assigned.
 #' Keywords can be added with the function `add_keywords`. The function
 #' `start_db` exports the table *batch_keywords* as objects
-#' `keywords_control` and `keywords_object` to the package environment.
+#' `keywords_control` and `keywords_object` to the package environment
+#' `gt.env`.
 #'
 #' Example data for the table *batch_keywords* is available as R object
 #' `example_keywords`.
@@ -64,8 +65,8 @@
 #' gets the value *world* as location. Data is downloaded and automatically
 #' written to the table through the function `download_control`. The
 #' function `start_db` exports the table *data_control* as database
-#' connection `tbl_control` to the package environment. Users can access the
-#' database table through `dplyr::tbl`.
+#' connection `tbl_control` to the package environment `gt.env`. Users
+#' can access the database table through `dplyr::tbl`.
 #' The sample data included in `data_control` was simulated based on actual
 #' Google Trends data.
 #'
@@ -103,8 +104,8 @@
 #' mapped. Global data takes the value *world* as location. Data is
 #' downloaded and automatically written to the table through the function
 #' `download_object`. The function `start_db` exports the table
-#' *data_object* as database connection `tbl_object` to
-#' the package environment. Users can access the database table through
+#' *data_object* as database connection `tbl_object` to the package
+#' environment `gt.env`. Users can access the database table through
 #' `dplyr::tbl`.
 #' The sample data included in `data_object` was simulated based on actual
 #' Google Trends data.
@@ -148,8 +149,8 @@
 #' scores are computed and automatically written to the table with the function
 #' `compute_score`. The function `start_db` exports the table
 #' *data_score* as database connection `tbl_score` to
-#' the package environment. Users can access the database table through
-#' `dplyr::tbl`.
+#' the package environment `gt.env`. Users can access the database
+#' table through `dplyr::tbl`.
 #' The sample data included in `data_score` was simulated based on actual
 #' Google Trends data.
 #'
@@ -199,8 +200,8 @@
 #' distribution of search scores. DOI is computed and automatically written to
 #' the table with the function `compute_doi`. The function `start_db`
 #' exports the table *data_doi* as database connection `tbl_doi` to
-#' the package environment. Users can access the database table through
-#' `dplyr::tbl`.
+#' the package environment `gt.env`. Users can access the database table
+#' through `dplyr::tbl`.
 #' The sample data included in `data_doi` was simulated based on actual
 #' Google Trends data.
 #'

--- a/R/database_functions.r
+++ b/R/database_functions.r
@@ -223,7 +223,7 @@ initialize_db <- function() {
 #' * [dplyr::tbl()]
 #'
 #' @return
-#' The function exports the following objects to the globaltrends namespace:
+#' The function exports the following objects to the package environment `globaltrends_db`:
 #' \itemize{
 #'   \item globaltrends_db A DBIConnection object, as returned by
 #'   `DBI::dbConnect()`, connecting to the SQLite database in the working
@@ -300,7 +300,7 @@ start_db <- function() {
   time_object <- collect(time_object)
   keyword_synonyms <- collect(tbl_synonyms)
 
-  # write objects to the package environment -----------------------------------
+  # write objects to the package environment gt.env ----------------------------
   lst_object <- list(
     tbl_locations,
     tbl_keywords,
@@ -331,7 +331,7 @@ start_db <- function() {
     ".time_object",
     ".keyword_synonyms"
   )
-  invisible(list2env(lst_object, envir = as.environment("package:globaltrends")))
+  invisible(list2env(lst_object, envir = gt.env))
   lst_object <- list(
     globaltrends_db,
     tbl_doi,
@@ -356,10 +356,10 @@ start_db <- function() {
     "time_object",
     "keyword_synonyms"
   )
-  invisible(list2env(lst_object, envir = as.environment("package:globaltrends")))
+  invisible(list2env(lst_object, envir = gt.env))
   
   .export_locations()
-  message("Successfully exported all objects to globaltrends namespace.")
+  message("Successfully exported all objects to package environment gt.env.")
 }
 
 #' @title Disconnect from database
@@ -378,7 +378,7 @@ start_db <- function() {
 #' * [start_db()]
 #'
 #' @param db Connection to database file that should be closed. Defaults
-#' to `globaltrends_db`.
+#' to `gt.env$globaltrends_db`.
 #'
 #' @return
 #' Message that disconnection was successful.
@@ -391,7 +391,7 @@ start_db <- function() {
 #' @importFrom DBI dbDisconnect
 
 
-disconnect_db <- function(db = globaltrends_db) {
+disconnect_db <- function(db = gt.env$globaltrends_db) {
   dbDisconnect(conn = db)
   message("Successfully disconnected.")
 }

--- a/R/download_control.r
+++ b/R/download_control.r
@@ -58,21 +58,21 @@
 #' @importFrom purrr walk
 #' @importFrom rlang .data
 
-download_control <- function(control, locations = countries, ...) UseMethod("download_control", control)
+download_control <- function(control, locations = gt.env$countries, ...) UseMethod("download_control", control)
 
 #' @rdname download_control
 #' @method download_control numeric
 #' @export
 
-download_control.numeric <- function(control, locations = countries, ...) {
+download_control.numeric <- function(control, locations = gt.env$countries, ...) {
   args <- list(...)
   .check_input(locations, "character")
   if (length(control) > 1) {
     download_control(control = as.list(control), locations = locations, ...)
   } else {
     .check_batch(control)
-    terms <- .keywords_control$keyword[.keywords_control$batch == control]
-    time <- .time_control$time[.time_control$batch == control]
+    terms <- gt.env$.keywords_control$keyword[gt.env$.keywords_control$batch == control]
+    time <- gt.env$.time_control$time[gt.env$.time_control$batch == control]
     walk(locations, ~ {
       if (.x == "") {
         in_location <- "world"
@@ -83,7 +83,7 @@ download_control.numeric <- function(control, locations = countries, ...) {
         out <- do.call(.get_trend, c(args, location = .x, term = list(terms), time = time))
         if (!is.null(out)) {
           out <- mutate(out, batch = control)
-          dbWriteTable(conn = globaltrends_db, name = "data_control", value = out, append = TRUE)
+          dbWriteTable(conn = gt.env$globaltrends_db, name = "data_control", value = out, append = TRUE)
         }
         message(glue("Successfully downloaded control data | control: {control} | location: {in_location} [{current}/{total}]",
           current = which(locations == .x), total = length(locations)
@@ -101,7 +101,7 @@ download_control.numeric <- function(control, locations = countries, ...) {
 #' @method download_control list
 #' @export
 
-download_control.list <- function(control, locations = countries, ...) {
+download_control.list <- function(control, locations = gt.env$countries, ...) {
   walk(control, download_control, locations = locations, ...)
 }
 

--- a/R/download_object.r
+++ b/R/download_object.r
@@ -64,13 +64,13 @@
 #' @importFrom purrr walk
 #' @importFrom rlang .data
 
-download_object <- function(object, control = 1, locations = countries, ...) UseMethod("download_object", object)
+download_object <- function(object, control = 1, locations = gt.env$countries, ...) UseMethod("download_object", object)
 
 #' @rdname download_object
 #' @method download_object numeric
 #' @export
 
-download_object.numeric <- function(object, control = 1, locations = countries, ...) {
+download_object.numeric <- function(object, control = 1, locations = gt.env$countries, ...) {
   args <- list(...)
   .check_length(control, 1)
   .check_input(locations, "character")
@@ -78,8 +78,8 @@ download_object.numeric <- function(object, control = 1, locations = countries, 
     download_object(control = control, object = as.list(object), locations = locations, ...)
   } else {
     walk(list(control, object), .check_batch)
-    terms_obj <- .keywords_object$keyword[.keywords_object$batch == object]
-    time <- .time_object$time[.time_object$batch == object]
+    terms_obj <- gt.env$.keywords_object$keyword[gt.env$.keywords_object$batch == object]
+    time <- gt.env$.time_object$time[gt.env$.time_object$batch == object]
 
     walk(locations, ~ {
       if (.x == "") {
@@ -88,7 +88,7 @@ download_object.numeric <- function(object, control = 1, locations = countries, 
         in_location <- .x
       }
       if (.test_empty(table = "data_object", batch_o = object, batch_c = control, location = in_location)) {
-        qry_control <- filter(.tbl_control, .data$batch == control & .data$location == in_location)
+        qry_control <- filter(gt.env$.tbl_control, .data$batch == control & .data$location == in_location)
         qry_control <- collect(qry_control)
         if (nrow(qry_control) > 0) {
           terms_con <- summarise(
@@ -109,7 +109,7 @@ download_object.numeric <- function(object, control = 1, locations = countries, 
                 batch_c = control,
                 batch_o = object
               )
-              dbWriteTable(conn = globaltrends_db, name = "data_object", value = out, append = TRUE)
+              dbWriteTable(conn = gt.env$globaltrends_db, name = "data_object", value = out, append = TRUE)
               success <- TRUE
               break()
             }
@@ -135,7 +135,7 @@ download_object.numeric <- function(object, control = 1, locations = countries, 
 #' @method download_object list
 #' @export
 
-download_object.list <- function(object, control = 1, locations = countries, ...) {
+download_object.list <- function(object, control = 1, locations = gt.env$countries, ...) {
   walk(object, download_object, control = control, locations = locations, ...)
 }
 

--- a/R/export_data.r
+++ b/R/export_data.r
@@ -102,7 +102,7 @@
 
 export_control <- function(control = NULL, location = NULL) {
   out <- .export_data(
-    table = .tbl_control,
+    table = gt.env$.tbl_control,
     in_batch = unlist(control),
     in_location = unlist(location)
   )
@@ -116,7 +116,7 @@ export_control <- function(control = NULL, location = NULL) {
 
 export_control_global <- function(control = NULL) {
   out <- .export_data(
-    table = .tbl_control,
+    table = gt.env$.tbl_control,
     in_batch = unlist(control),
     in_location = "world"
   )
@@ -129,7 +129,7 @@ export_control_global <- function(control = NULL) {
 
 export_object <- function(keyword = NULL, object = NULL, control = NULL, location = NULL) {
   out <- .export_data(
-    table = .tbl_object,
+    table = gt.env$.tbl_object,
     in_keyword = unlist(keyword),
     in_object = unlist(object),
     in_control = unlist(control),
@@ -145,7 +145,7 @@ export_object <- function(keyword = NULL, object = NULL, control = NULL, locatio
 
 export_object_global <- function(keyword = NULL, object = NULL, control = NULL) {
   out <- .export_data(
-    table = .tbl_object,
+    table = gt.env$.tbl_object,
     in_keyword = unlist(keyword),
     in_object = unlist(object),
     in_control = unlist(control),
@@ -160,7 +160,7 @@ export_object_global <- function(keyword = NULL, object = NULL, control = NULL) 
 
 export_score <- function(keyword = NULL, object = NULL, control = NULL, location = NULL) {
   out <- .export_data(
-    table = .tbl_score,
+    table = gt.env$.tbl_score,
     in_keyword = unlist(keyword),
     in_object = unlist(object),
     in_control = unlist(control),
@@ -178,7 +178,7 @@ export_score <- function(keyword = NULL, object = NULL, control = NULL, location
 
 export_voi <- function(keyword = NULL, object = NULL, control = NULL) {
   out <- .export_data(
-    table = .tbl_score,
+    table = gt.env$.tbl_score,
     in_keyword = unlist(keyword),
     in_object = unlist(object),
     in_control = unlist(control),
@@ -196,7 +196,7 @@ export_voi <- function(keyword = NULL, object = NULL, control = NULL) {
 
 export_doi <- function(keyword = NULL, object = NULL, control = NULL, locations = NULL, type = NULL) {
   out <- .export_data(
-    table = .tbl_doi,
+    table = gt.env$.tbl_doi,
     in_keyword = unlist(keyword),
     in_object = unlist(object),
     in_control = unlist(control),

--- a/R/helper_functions.r
+++ b/R/helper_functions.r
@@ -52,15 +52,15 @@
     in_location <- location
     in_locations <- locations
     if (table == "data_control") {
-      out <- filter(.tbl_control, .data$batch == in_batch_c & .data$location == in_location)
+      out <- filter(gt.env$.tbl_control, .data$batch == in_batch_c & .data$location == in_location)
     } else if (table == "data_object") {
-      out <- filter(.tbl_object, .data$batch_c == in_batch_c & .data$batch_o == in_batch_o & .data$location == in_location)
+      out <- filter(gt.env$.tbl_object, .data$batch_c == in_batch_c & .data$batch_o == in_batch_o & .data$location == in_location)
     } else if (table == "data_score") {
-      out <- filter(.tbl_score, .data$batch_c == in_batch_c & .data$batch_o == in_batch_o & .data$location == in_location)
+      out <- filter(gt.env$.tbl_score, .data$batch_c == in_batch_c & .data$batch_o == in_batch_o & .data$location == in_location)
     } else if (table == "data_doi") {
-      out <- filter(.tbl_doi, .data$batch_c == in_batch_c & .data$batch_o == in_batch_o & .data$locations == in_locations)
+      out <- filter(gt.env$.tbl_doi, .data$batch_c == in_batch_c & .data$batch_o == in_batch_o & .data$locations == in_locations)
     } else if (table == "data_global") {
-      out <- filter(.tbl_global, .data$batch == in_batch_o)
+      out <- filter(gt.env$.tbl_global, .data$batch == in_batch_o)
     }
     out <- utils::head(out)
     out <- collect(out)

--- a/R/remove_data.r
+++ b/R/remove_data.r
@@ -93,24 +93,24 @@ remove_data <- function(table, control = NULL, object = NULL) {
 .remove_batch_keywords <- function(type, batch_c, batch_o) {
   walk(list(batch_c, batch_o), .check_batch)
   if (type == "control") {
-    dbExecute(conn = globaltrends_db, statement = "DELETE FROM batch_keywords WHERE type=? AND batch=?", params = list(type, batch_c))
-    keywords_control <- filter(.tbl_keywords, .data$type == "control")
+    dbExecute(conn = gt.env$globaltrends_db, statement = "DELETE FROM batch_keywords WHERE type=? AND batch=?", params = list(type, batch_c))
+    keywords_control <- filter(gt.env$.tbl_keywords, .data$type == "control")
     keywords_control <- select(keywords_control, -.data$type)
     keywords_control <- collect(keywords_control)
     lst_export <- list(keywords_control, keywords_control)
     names(lst_export) <- list("keywords_control", ".keywords_control")
-    invisible(list2env(lst_export, envir = as.environment("package:globaltrends")))
+    invisible(list2env(lst_export, envir = gt.env))
     message(glue("Successfully deleted control batch {batch_c} from 'batch_keywords'."))
 
     .remove_data_control(batch_c = batch_c)
   } else if (type == "object") {
-    dbExecute(conn = globaltrends_db, statement = "DELETE FROM batch_keywords WHERE type=? AND batch=?", params = list(type, batch_o))
-    keywords_object <- filter(.tbl_keywords, .data$type == "object")
+    dbExecute(conn = gt.env$globaltrends_db, statement = "DELETE FROM batch_keywords WHERE type=? AND batch=?", params = list(type, batch_o))
+    keywords_object <- filter(gt.env$.tbl_keywords, .data$type == "object")
     keywords_object <- select(keywords_object, -.data$type)
     keywords_object <- collect(keywords_object)
     lst_export <- list(keywords_object, keywords_object)
     names(lst_export) <- list("keywords_object", ".keywords_object")
-    invisible(list2env(lst_export, envir = as.environment("package:globaltrends")))
+    invisible(list2env(lst_export, envir = gt.env))
     message(glue("Successfully deleted object batch {batch_o} from 'batch_keywords'."))
 
     .remove_data_object(batch_o = batch_o)
@@ -126,22 +126,22 @@ remove_data <- function(table, control = NULL, object = NULL) {
 .remove_batch_time <- function(type, batch_c = NULL, batch_o = NULL) {
   walk(list(batch_c, batch_o), .check_batch)
   if (type == "control") {
-    dbExecute(conn = globaltrends_db, statement = "DELETE FROM batch_time WHERE type=? AND batch=?", params = list(type, batch_c))
-    time_control <- filter(.tbl_time, .data$type == "control")
+    dbExecute(conn = gt.env$globaltrends_db, statement = "DELETE FROM batch_time WHERE type=? AND batch=?", params = list(type, batch_c))
+    time_control <- filter(gt.env$.tbl_time, .data$type == "control")
     time_control <- select(time_control, -.data$type)
     time_control <- collect(time_control)
     lst_export <- list(time_control, time_control)
     names(lst_export) <- list("time_control", ".time_control")
-    invisible(list2env(lst_export, envir = as.environment("package:globaltrends")))
+    invisible(list2env(lst_export, envir = gt.env))
     message(glue("Successfully deleted control batch {batch_c} from 'batch_time'."))
   } else if (type == "object") {
-    dbExecute(conn = globaltrends_db, statement = "DELETE FROM batch_time WHERE type=? AND batch=?", params = list(type, batch_o))
-    time_object <- filter(.tbl_time, .data$type == "object")
+    dbExecute(conn = gt.env$globaltrends_db, statement = "DELETE FROM batch_time WHERE type=? AND batch=?", params = list(type, batch_o))
+    time_object <- filter(gt.env$.tbl_time, .data$type == "object")
     time_object <- select(time_object, -.data$type)
     time_object <- collect(time_object)
     lst_export <- list(time_object, time_object)
     names(lst_export) <- list("time_object", ".time_object")
-    invisible(list2env(lst_export, envir = as.environment("package:globaltrends")))
+    invisible(list2env(lst_export, envir = gt.env))
     message(glue("Successfully deleted object batch {batch_o} from 'batch_time'."))
   }
 }
@@ -152,7 +152,7 @@ remove_data <- function(table, control = NULL, object = NULL) {
 
 .remove_data_control <- function(batch_c = NULL, batch_o = NULL) {
   walk(list(batch_c, batch_o), .check_batch)
-  dbExecute(conn = globaltrends_db, statement = "DELETE FROM data_control WHERE batch=?", params = list(batch_c))
+  dbExecute(conn = gt.env$globaltrends_db, statement = "DELETE FROM data_control WHERE batch=?", params = list(batch_c))
   message(glue("Successfully deleted control batch {batch_c} from 'data_control'."))
 
   .remove_data_object(batch_c = batch_c)
@@ -165,13 +165,13 @@ remove_data <- function(table, control = NULL, object = NULL) {
 .remove_data_object <- function(batch_c = NULL, batch_o = NULL) {
   walk(list(batch_c, batch_o), .check_batch)
   if (is.null(batch_o) & !is.null(batch_c)) {
-    dbExecute(conn = globaltrends_db, statement = "DELETE FROM data_object WHERE batch_c=?", params = list(batch_c))
+    dbExecute(conn = gt.env$globaltrends_db, statement = "DELETE FROM data_object WHERE batch_c=?", params = list(batch_c))
     message(glue("Successfully deleted control batch {batch_c} from 'data_object'."))
   } else if (is.null(batch_c) & !is.null(batch_o)) {
-    dbExecute(conn = globaltrends_db, statement = "DELETE FROM data_object WHERE batch_o=?", params = list(batch_o))
+    dbExecute(conn = gt.env$globaltrends_db, statement = "DELETE FROM data_object WHERE batch_o=?", params = list(batch_o))
     message(glue("Successfully deleted object batch {batch_o} from 'data_object'."))
   } else if (!is.null(batch_o) & !is.null(batch_c)) {
-    dbExecute(conn = globaltrends_db, statement = "DELETE FROM data_object WHERE batch_o=? AND batch_c=?", params = list(batch_c, batch_o))
+    dbExecute(conn = gt.env$globaltrends_db, statement = "DELETE FROM data_object WHERE batch_o=? AND batch_c=?", params = list(batch_c, batch_o))
     message(glue("Successfully deleted control batch {batch_c} and object batch {batch_o} from 'data_object'."))
   }
 
@@ -185,13 +185,13 @@ remove_data <- function(table, control = NULL, object = NULL) {
 .remove_data_score <- function(batch_c = NULL, batch_o = NULL) {
   walk(list(batch_c, batch_o), .check_batch)
   if (is.null(batch_o) & !is.null(batch_c)) {
-    dbExecute(conn = globaltrends_db, statement = "DELETE FROM data_score WHERE batch_c=?", params = list(batch_c))
+    dbExecute(conn = gt.env$globaltrends_db, statement = "DELETE FROM data_score WHERE batch_c=?", params = list(batch_c))
     message(glue("Successfully deleted control batch {batch_c} from 'data_score'."))
   } else if (is.null(batch_c) & !is.null(batch_o)) {
-    dbExecute(conn = globaltrends_db, statement = "DELETE FROM data_score WHERE batch_o=?", params = list(batch_o))
+    dbExecute(conn = gt.env$globaltrends_db, statement = "DELETE FROM data_score WHERE batch_o=?", params = list(batch_o))
     message(glue("Successfully deleted object batch {batch_o} from 'data_score'."))
   } else if (!is.null(batch_o) & !is.null(batch_c)) {
-    dbExecute(conn = globaltrends_db, statement = "DELETE FROM data_score WHERE batch_o=? AND batch_c=?", params = list(batch_c, batch_o))
+    dbExecute(conn = gt.env$globaltrends_db, statement = "DELETE FROM data_score WHERE batch_o=? AND batch_c=?", params = list(batch_c, batch_o))
     message(glue("Successfully deleted control batch {batch_c} and object batch {batch_o} from 'data_score'."))
   }
 
@@ -205,13 +205,13 @@ remove_data <- function(table, control = NULL, object = NULL) {
 .remove_data_doi <- function(batch_c = NULL, batch_o = NULL) {
   walk(list(batch_c, batch_o), .check_batch)
   if (is.null(batch_o) & !is.null(batch_c)) {
-    dbExecute(conn = globaltrends_db, statement = "DELETE FROM data_doi WHERE batch_c=?", params = list(batch_c))
+    dbExecute(conn = gt.env$globaltrends_db, statement = "DELETE FROM data_doi WHERE batch_c=?", params = list(batch_c))
     message(glue("Successfully deleted control batch {batch_c} from 'data_doi'."))
   } else if (is.null(batch_c) & !is.null(batch_o)) {
-    dbExecute(conn = globaltrends_db, statement = "DELETE FROM data_doi WHERE batch_o=?", params = list(batch_o))
+    dbExecute(conn = gt.env$globaltrends_db, statement = "DELETE FROM data_doi WHERE batch_o=?", params = list(batch_o))
     message(glue("Successfully deleted object batch {batch_o} from 'data_doi'."))
   } else if (!is.null(batch_o) & !is.null(batch_c)) {
-    dbExecute(conn = globaltrends_db, statement = "DELETE FROM data_doi WHERE batch_o=? AND batch_c=?", params = list(batch_c, batch_o))
+    dbExecute(conn = gt.env$globaltrends_db, statement = "DELETE FROM data_doi WHERE batch_o=? AND batch_c=?", params = list(batch_c, batch_o))
     message(glue("Successfully deleted control batch {batch_c} and object batch {batch_o} from 'data_doi'."))
   }
 }
@@ -222,6 +222,6 @@ remove_data <- function(table, control = NULL, object = NULL) {
 
 .remove_data_global <- function(batch_c = NULL, batch_o = NULL) {
   walk(list(batch_c, batch_o), .check_batch)
-  dbExecute(conn = globaltrends_db, statement = "DELETE FROM data_global WHERE batch=?", params = list(batch_o))
+  dbExecute(conn = gt.env$globaltrends_db, statement = "DELETE FROM data_global WHERE batch=?", params = list(batch_o))
   message(glue("Successfully deleted object batch {batch_o} from 'data_global'."))
 }

--- a/R/zzz.r
+++ b/R/zzz.r
@@ -1,0 +1,31 @@
+gt.env <- new.env(parent = emptyenv())
+.onLoad <- function(libname, pkgname) {
+  lst_name <- list(
+    ".tbl_locations",
+    ".tbl_keywords",
+    ".tbl_time",
+    ".tbl_doi",
+    ".tbl_control",
+    ".tbl_object",
+    ".tbl_score",
+    ".tbl_synonyms",
+    ".keywords_control",
+    ".time_control",
+    ".keywords_object",
+    ".time_object",
+    ".keyword_synonyms",
+    "globaltrends_db",
+    "tbl_doi",
+    "tbl_control",
+    "tbl_object",
+    "tbl_score",
+    "keywords_control",
+    "time_control",
+    "keywords_object",
+    "time_object",
+    "keyword_synonyms"
+  )
+  lst_object <- as.list(rep(TRUE, length(lst_name)))
+  names(lst_object) <- lst_name
+  invisible(list2env(lst_object, envir = gt.env))
+}

--- a/man/add_locations.Rd
+++ b/man/add_locations.Rd
@@ -4,7 +4,7 @@
 \alias{add_locations}
 \title{Add sets of locations}
 \usage{
-add_locations(locations, type, export = TRUE, db = globaltrends_db)
+add_locations(locations, type, export = TRUE, db = gt.env$globaltrends_db)
 }
 \arguments{
 \item{locations}{Locations that should be added as set of locations. Vector of
@@ -14,11 +14,11 @@ type \code{character}.}
 \code{character} of length 1.}
 
 \item{export}{Indicator whether the new location set should be directly
-exported to the package environment. Object of type \code{logical}, defaults to
-\code{TRUE}.}
+exported to the package environment \code{gt.env}. Object of type \code{logical},
+defaults to \code{TRUE}.}
 
 \item{db}{Connection to database file that should be closed. Defaults
-to \code{globaltrends_db}.}
+to \code{gt.env$globaltrends_db}.}
 }
 \value{
 Message that the location set has been created successfully. Location data is

--- a/man/batch_keywords.Rd
+++ b/man/batch_keywords.Rd
@@ -25,7 +25,8 @@ line contains one \emph{keyword}, the \emph{type} of the batch (i.e., control
 or object) and the id of the \emph{batch} to which the keyword is assigned.
 Keywords can be added with the function \code{add_keywords}. The function
 \code{start_db} exports the table \emph{batch_keywords} as objects
-\code{keywords_control} and \code{keywords_object} to the package environment.
+\code{keywords_control} and \code{keywords_object} to the package environment
+\code{gt.env}.
 
 Example data for the table \emph{batch_keywords} is available as R object
 \code{example_keywords}.

--- a/man/compute_score.Rd
+++ b/man/compute_score.Rd
@@ -7,11 +7,11 @@
 \alias{compute_voi}
 \title{Compute keyword-country search score}
 \usage{
-compute_score(object, control = 1, locations = countries)
+compute_score(object, control = 1, locations = gt.env$countries)
 
-\method{compute_score}{numeric}(object, control = 1, locations = countries)
+\method{compute_score}{numeric}(object, control = 1, locations = gt.env$countries)
 
-\method{compute_score}{list}(object, control = 1, locations = countries)
+\method{compute_score}{list}(object, control = 1, locations = gt.env$countries)
 
 compute_voi(object, control = 1)
 }

--- a/man/data_control.Rd
+++ b/man/data_control.Rd
@@ -31,8 +31,8 @@ control \emph{batch} for a given \emph{location} and \emph{date}. Global data
 gets the value \emph{world} as location. Data is downloaded and automatically
 written to the table through the function \code{download_control}. The
 function \code{start_db} exports the table \emph{data_control} as database
-connection \code{tbl_control} to the package environment. Users can access the
-database table through \code{dplyr::tbl}.
+connection \code{tbl_control} to the package environment \code{gt.env}. Users
+can access the database table through \code{dplyr::tbl}.
 The sample data included in \code{data_control} was simulated based on actual
 Google Trends data.
 

--- a/man/data_doi.Rd
+++ b/man/data_doi.Rd
@@ -47,8 +47,8 @@ control batch that has been used as baseline for mapping. Column
 distribution of search scores. DOI is computed and automatically written to
 the table with the function \code{compute_doi}. The function \code{start_db}
 exports the table \emph{data_doi} as database connection \code{tbl_doi} to
-the package environment. Users can access the database table through
-\code{dplyr::tbl}.
+the package environment \code{gt.env}. Users can access the database table
+through \code{dplyr::tbl}.
 The sample data included in \code{data_doi} was simulated based on actual
 Google Trends data.
 }

--- a/man/data_object.Rd
+++ b/man/data_object.Rd
@@ -37,8 +37,8 @@ column \emph{batch_c} indicates the control batch to which the data will be
 mapped. Global data takes the value \emph{world} as location. Data is
 downloaded and automatically written to the table through the function
 \code{download_object}. The function \code{start_db} exports the table
-\emph{data_object} as database connection \code{tbl_object} to
-the package environment. Users can access the database table through
+\emph{data_object} as database connection \code{tbl_object} to the package
+environment \code{gt.env}. Users can access the database table through
 \code{dplyr::tbl}.
 The sample data included in \code{data_object} was simulated based on actual
 Google Trends data.

--- a/man/data_score.Rd
+++ b/man/data_score.Rd
@@ -44,8 +44,8 @@ for mapping. Global data takes the value \emph{world} as location. Search
 scores are computed and automatically written to the table with the function
 \code{compute_score}. The function \code{start_db} exports the table
 \emph{data_score} as database connection \code{tbl_score} to
-the package environment. Users can access the database table through
-\code{dplyr::tbl}.
+the package environment \code{gt.env}. Users can access the database
+table through \code{dplyr::tbl}.
 The sample data included in \code{data_score} was simulated based on actual
 Google Trends data.
 

--- a/man/disconnect_db.Rd
+++ b/man/disconnect_db.Rd
@@ -4,11 +4,11 @@
 \alias{disconnect_db}
 \title{Disconnect from database}
 \usage{
-disconnect_db(db = globaltrends_db)
+disconnect_db(db = gt.env$globaltrends_db)
 }
 \arguments{
 \item{db}{Connection to database file that should be closed. Defaults
-to \code{globaltrends_db}.}
+to \code{gt.env$globaltrends_db}.}
 }
 \value{
 Message that disconnection was successful.

--- a/man/download_control.Rd
+++ b/man/download_control.Rd
@@ -7,11 +7,11 @@
 \alias{download_control_global}
 \title{Download data for control keywords}
 \usage{
-download_control(control, locations = countries, ...)
+download_control(control, locations = gt.env$countries, ...)
 
-\method{download_control}{numeric}(control, locations = countries, ...)
+\method{download_control}{numeric}(control, locations = gt.env$countries, ...)
 
-\method{download_control}{list}(control, locations = countries, ...)
+\method{download_control}{list}(control, locations = gt.env$countries, ...)
 
 download_control_global(control, ...)
 }

--- a/man/download_object.Rd
+++ b/man/download_object.Rd
@@ -7,11 +7,11 @@
 \alias{download_object_global}
 \title{Download data for object batch}
 \usage{
-download_object(object, control = 1, locations = countries, ...)
+download_object(object, control = 1, locations = gt.env$countries, ...)
 
-\method{download_object}{numeric}(object, control = 1, locations = countries, ...)
+\method{download_object}{numeric}(object, control = 1, locations = gt.env$countries, ...)
 
-\method{download_object}{list}(object, control = 1, locations = countries, ...)
+\method{download_object}{list}(object, control = 1, locations = gt.env$countries, ...)
 
 download_object_global(object, control = 1, ...)
 }

--- a/man/start_db.Rd
+++ b/man/start_db.Rd
@@ -7,7 +7,7 @@
 start_db()
 }
 \value{
-The function exports the following objects to the globaltrends namespace:
+The function exports the following objects to the package environment \code{globaltrends_db}:
 \itemize{
 \item globaltrends_db A DBIConnection object, as returned by
 \code{DBI::dbConnect()}, connecting to the SQLite database in the working

--- a/tests/testthat/test-24months.R
+++ b/tests/testthat/test-24months.R
@@ -10,16 +10,16 @@ start_db()
 remove_data("data_control", control = 1)
 remove_data("data_object", object = 1)
 data <- filter(example_control, batch == 1)
-dbWriteTable(globaltrends_db, "data_control", data, append = TRUE)
+dbWriteTable(gt.env$globaltrends_db, "data_control", data, append = TRUE)
 data <- filter(example_object, batch_c == 1 & batch_o == 1 & year(as_date(date)) == 2019)
-dbWriteTable(globaltrends_db, "data_object", data, append = TRUE)
+dbWriteTable(gt.env$globaltrends_db, "data_object", data, append = TRUE)
 .keywords_object <- data %>%
   select(
     batch = batch_o,
     keyword
   ) %>%
   unique()
-assign(".keywords_object", .keywords_object, envir = as.environment("package:globaltrends"))
+assign(".keywords_object", .keywords_object, envir = gt.env)
 
 test_that("score1", {
   expect_warning(
@@ -39,9 +39,9 @@ test_that("score2", {
 remove_data("data_control", control = 1)
 remove_data("data_object", object = 1)
 data <- filter(example_control, batch == 1 & year(as_date(date)) == 2019)
-dbWriteTable(globaltrends_db, "data_control", data, append = TRUE)
+dbWriteTable(gt.env$globaltrends_db, "data_control", data, append = TRUE)
 data <- filter(example_object, batch_c == 1 & batch_o == 1)
-dbWriteTable(globaltrends_db, "data_object", data, append = TRUE)
+dbWriteTable(gt.env$globaltrends_db, "data_object", data, append = TRUE)
 
 test_that("score3", {
   expect_warning(
@@ -61,9 +61,9 @@ test_that("score4", {
 remove_data("data_control", control = 1)
 remove_data("data_object", object = 1)
 data <- filter(example_control, batch == 1 & year(as_date(date)) == 2019)
-dbWriteTable(globaltrends_db, "data_control", data, append = TRUE)
+dbWriteTable(gt.env$globaltrends_db, "data_control", data, append = TRUE)
 data <- filter(example_object, batch_c == 1 & batch_o == 1 & year(as_date(date)) == 2019)
-dbWriteTable(globaltrends_db, "data_object", data, append = TRUE)
+dbWriteTable(gt.env$globaltrends_db, "data_object", data, append = TRUE)
 
 test_that("score5", {
   expect_warning(

--- a/tests/testthat/test-abnorm.R
+++ b/tests/testthat/test-abnorm.R
@@ -9,14 +9,14 @@ initialize_db()
 start_db()
 
 # enter data -------------------------------------------------------------------
-data <- filter(example_control, batch == 1 & location %in% c(countries[1:2], "world"))
-dbWriteTable(globaltrends_db, "data_control", data, append = TRUE)
-data <- filter(example_object, batch_c == 1 & batch_o %in% 1:3 & location %in% c(countries[1:2], "world"))
-dbWriteTable(globaltrends_db, "data_object", data, append = TRUE)
-data <- filter(example_score, batch_c == 1 & batch_o %in% 1:3 & location %in% c(countries[1:2], "world"))
-dbWriteTable(globaltrends_db, "data_score", data, append = TRUE)
+data <- filter(example_control, batch == 1 & location %in% c(gt.env$countries[1:2], "world"))
+dbWriteTable(gt.env$globaltrends_db, "data_control", data, append = TRUE)
+data <- filter(example_object, batch_c == 1 & batch_o %in% 1:3 & location %in% c(gt.env$countries[1:2], "world"))
+dbWriteTable(gt.env$globaltrends_db, "data_object", data, append = TRUE)
+data <- filter(example_score, batch_c == 1 & batch_o %in% 1:3 & location %in% c(gt.env$countries[1:2], "world"))
+dbWriteTable(gt.env$globaltrends_db, "data_score", data, append = TRUE)
 data <- filter(example_doi, batch_c == 1 & batch_o %in% 1:3 & locations == "countries")
-dbWriteTable(globaltrends_db, "data_doi", data, append = TRUE)
+dbWriteTable(gt.env$globaltrends_db, "data_doi", data, append = TRUE)
 
 # get_abnorm_hist.exp_score ---------------------------------------------------
 data <- export_score(object = 1)

--- a/tests/testthat/test-computations.R
+++ b/tests/testthat/test-computations.R
@@ -19,14 +19,14 @@ add_object_keyword(
   time = "2010-01-01 2019-12-31"
 )
 
-data <- filter(example_control, batch == 1 & location %in% c(countries[1:3], "world"))
-dbWriteTable(globaltrends_db, "data_control", data, append = TRUE)
-data <- filter(example_object, batch_c == 1 & batch_o == 1 & location %in% c(countries[1:3], "world"))
-dbWriteTable(globaltrends_db, "data_object", data, append = TRUE)
+data <- filter(example_control, batch == 1 & location %in% c(gt.env$countries[1:3], "world"))
+dbWriteTable(gt.env$globaltrends_db, "data_control", data, append = TRUE)
+data <- filter(example_object, batch_c == 1 & batch_o == 1 & location %in% c(gt.env$countries[1:3], "world"))
+dbWriteTable(gt.env$globaltrends_db, "data_object", data, append = TRUE)
 
 # compute score ----------------------------------------------------------------
 test_that("compute_score1", {
-  out <- capture_messages(compute_score(control = 1, object = 1, locations = countries[1:3]))
+  out <- capture_messages(compute_score(control = 1, object = 1, locations = gt.env$countries[1:3]))
 
   expect_match(
     out,
@@ -44,7 +44,7 @@ test_that("compute_score1", {
     all = FALSE
   )
 
-  out <- filter(.tbl_score, batch_c == 1 & batch_o == 1 & location != "world")
+  out <- filter(gt.env$.tbl_score, batch_c == 1 & batch_o == 1 & location != "world")
   out <- collect(out)
   expect_equal(nrow(out), 1440)
 })
@@ -76,7 +76,7 @@ test_that("compute_voi1", {
     compute_voi(control = 1, object = 1),
     "Successfully computed search score | control: 1 | object: 1 | location: world [1/1]",
   )
-  out <- filter(.tbl_score, batch_c == 1 & batch_o == 1 & location == "world")
+  out <- filter(gt.env$.tbl_score, batch_c == 1 & batch_o == 1 & location == "world")
   out <- collect(out)
   expect_equal(nrow(out), 480)
 })
@@ -87,7 +87,7 @@ test_that("compute_doi1", {
     compute_doi(control = 1, object = 1, locations = "countries"),
     "Successfully computed DOI | control: 1 | object: 1 [1/1]"
   )
-  out <- filter(.tbl_doi, batch_c == 1 & batch_o == 1)
+  out <- filter(gt.env$.tbl_doi, batch_c == 1 & batch_o == 1)
   out <- collect(out)
   expect_equal(nrow(out), 1440)
 })
@@ -148,8 +148,8 @@ test_that("remove_data1", {
     all = FALSE
   )
 
-  out_keywords <- filter(.tbl_keywords, batch == 1 & type == "control")
-  out_time <- filter(.tbl_time, batch == 1 & type == "control")
+  out_keywords <- filter(gt.env$.tbl_keywords, batch == 1 & type == "control")
+  out_time <- filter(gt.env$.tbl_time, batch == 1 & type == "control")
   out_keywords <- collect(out_keywords)
   out_time <- collect(out_time)
   expect_equal(nrow(out_keywords), 0)
@@ -185,8 +185,8 @@ test_that("remove_data2", {
     all = FALSE
   )
 
-  out_keywords <- filter(.tbl_keywords, batch == 1 & type == "object")
-  out_time <- filter(.tbl_time, batch == 1 & type == "object")
+  out_keywords <- filter(gt.env$.tbl_keywords, batch == 1 & type == "object")
+  out_time <- filter(gt.env$.tbl_time, batch == 1 & type == "object")
   out_keywords <- collect(out_keywords)
   out_time <- collect(out_time)
   expect_equal(nrow(out_keywords), 0)

--- a/tests/testthat/test-downloads.R
+++ b/tests/testthat/test-downloads.R
@@ -21,7 +21,7 @@ add_object_keyword(
 # try download object ----------------------------------------------------------
 test_that("download_object1", {
   out <- expect_message(
-    download_object(object = 1, locations = countries[[1]]),
+    download_object(object = 1, locations = gt.env$countries[[1]]),
     "Download for object data failed.\nThere is no data in 'data_control' for control batch 1 and location US."
   )
 })
@@ -31,7 +31,7 @@ test_that("download_control1", {
   skip_on_cran()
   skip_if_offline()
   
-  out <- capture_messages(download_control(control = 1, locations = countries[1:3]))
+  out <- capture_messages(download_control(control = 1, locations = gt.env$countries[1:3]))
 
   expect_match(
     out,
@@ -49,7 +49,7 @@ test_that("download_control1", {
     all = FALSE
   )
 
-  out <- filter(.tbl_control, batch == 1 & location != "world")
+  out <- filter(gt.env$.tbl_control, batch == 1 & location != "world")
   out <- collect(out)
   expect_equal(nrow(out), 1800)
 })
@@ -60,7 +60,7 @@ test_that("download_control2", {
   skip_if_offline()
   
   expect_message(
-    download_control(control = 1, locations = countries[[1]]),
+    download_control(control = 1, locations = gt.env$countries[[1]]),
     "Control data already available | control: 1 | location: US [1/1]"
   )
 })
@@ -74,7 +74,7 @@ test_that("download_control3", {
     download_control_global(control = 1),
     "Successfully downloaded control data | control: 1 | location: world [1/1]"
   )
-  out <- filter(.tbl_control, batch == 1 & location == "world")
+  out <- filter(gt.env$.tbl_control, batch == 1 & location == "world")
   out <- collect(out)
   expect_equal(nrow(out), 600)
 })
@@ -108,7 +108,7 @@ test_that("download_object2", {
   skip_on_cran()
   skip_if_offline()
   
-  out <- capture_messages(download_object(object = 1, locations = countries[1:3]))
+  out <- capture_messages(download_object(object = 1, locations = gt.env$countries[1:3]))
 
   expect_match(
     out,
@@ -126,7 +126,7 @@ test_that("download_object2", {
     all = FALSE
   )
 
-  out <- filter(.tbl_object, batch_o == 1 & location != "world")
+  out <- filter(gt.env$.tbl_object, batch_o == 1 & location != "world")
   out <- collect(out)
   expect_equal(nrow(out), 1800)
 })
@@ -137,7 +137,7 @@ test_that("download_object3", {
   skip_if_offline()
   
   expect_message(
-    download_object(object = 1, locations = countries[[1]]),
+    download_object(object = 1, locations = gt.env$countries[[1]]),
     "Object data already available | object: 1 | control: 1 | location: US [1/1]"
   )
 })
@@ -151,7 +151,7 @@ test_that("download_object4", {
     download_object_global(object = 1),
     "Successfully downloaded object data | object: 1 | control: 1 | location: world [1/1]"
   )
-  out <- filter(.tbl_object, batch_o == 1 & location == "world")
+  out <- filter(gt.env$.tbl_object, batch_o == 1 & location == "world")
   out <- collect(out)
   expect_equal(nrow(out), 600)
 })

--- a/tests/testthat/test-export.R
+++ b/tests/testthat/test-export.R
@@ -9,14 +9,14 @@ initialize_db()
 start_db()
 
 # enter data -------------------------------------------------------------------
-data <- filter(example_control, batch == 1 & location %in% c(countries[1:2], "world"))
-dbWriteTable(globaltrends_db, "data_control", data, append = TRUE)
-data <- filter(example_object, batch_c == 1 & batch_o %in% 1:3 & location %in% c(countries[1:2], "world"))
-dbWriteTable(globaltrends_db, "data_object", data, append = TRUE)
-data <- filter(example_score, batch_c == 1 & batch_o %in% 1:3 & location %in% c(countries[1:2], "world"))
-dbWriteTable(globaltrends_db, "data_score", data, append = TRUE)
+data <- filter(example_control, batch == 1 & location %in% c(gt.env$countries[1:2], "world"))
+dbWriteTable(gt.env$globaltrends_db, "data_control", data, append = TRUE)
+data <- filter(example_object, batch_c == 1 & batch_o %in% 1:3 & location %in% c(gt.env$countries[1:2], "world"))
+dbWriteTable(gt.env$globaltrends_db, "data_object", data, append = TRUE)
+data <- filter(example_score, batch_c == 1 & batch_o %in% 1:3 & location %in% c(gt.env$countries[1:2], "world"))
+dbWriteTable(gt.env$globaltrends_db, "data_score", data, append = TRUE)
 data <- filter(example_doi, batch_c == 1 & batch_o %in% 1:3 & locations == "countries")
-dbWriteTable(globaltrends_db, "data_doi", data, append = TRUE)
+dbWriteTable(gt.env$globaltrends_db, "data_doi", data, append = TRUE)
 
 # export_control ---------------------------------------------------------------
 test_that("export_control1", {

--- a/tests/testthat/test-keywords.R
+++ b/tests/testthat/test-keywords.R
@@ -16,10 +16,10 @@ test_that("keywords_control1", {
     ),
     "Successfully created new control batch 1 \\(gmail, maps, translate, wikipedia, youtube, 2010-01-01 2019-12-31\\)\\."
   )
-  out_keywords <- filter(.tbl_keywords, batch == 1 & type == "control") %>%
+  out_keywords <- filter(gt.env$.tbl_keywords, batch == 1 & type == "control") %>%
     collect() %>%
     count(batch)
-  out_time <- filter(.tbl_time, batch == 1 & type == "control") %>%
+  out_time <- filter(gt.env$.tbl_time, batch == 1 & type == "control") %>%
     collect() %>%
     count(batch)
   expect_equal(out_keywords$n[[1]], 5)
@@ -45,10 +45,10 @@ test_that("keywords_control2", {
     all = FALSE
   )
 
-  out_keywords <- filter(.tbl_keywords, batch > 1 & type == "control") %>%
+  out_keywords <- filter(gt.env$.tbl_keywords, batch > 1 & type == "control") %>%
     collect() %>%
     count(batch)
-  out_time <- filter(.tbl_time, batch > 1 & type == "control") %>%
+  out_time <- filter(gt.env$.tbl_time, batch > 1 & type == "control") %>%
     collect() %>%
     count(batch)
   expect_equal(nrow(out_keywords), 2)
@@ -81,10 +81,10 @@ test_that("keywords_control3", {
     all = FALSE
   )
 
-  out_keywords <- filter(.tbl_keywords, batch > 3 & type == "control") %>%
+  out_keywords <- filter(gt.env$.tbl_keywords, batch > 3 & type == "control") %>%
     collect() %>%
     count(batch)
-  out_time <- filter(.tbl_time, batch > 3 & type == "control") %>%
+  out_time <- filter(gt.env$.tbl_time, batch > 3 & type == "control") %>%
     collect() %>%
     count(batch)
   expect_equal(nrow(out_keywords), 2)
@@ -104,10 +104,10 @@ test_that("keywords_object1", {
     ),
     "Successfully created new object batch 1 \\(apple, facebook, google, microsoft, 2010-01-01 2019-12-31\\)\\."
   )
-  out_keywords <- filter(.tbl_keywords, batch == 1 & type == "object") %>%
+  out_keywords <- filter(gt.env$.tbl_keywords, batch == 1 & type == "object") %>%
     collect() %>%
     count(batch)
-  out_time <- filter(.tbl_time, batch == 1 & type == "object") %>%
+  out_time <- filter(gt.env$.tbl_time, batch == 1 & type == "object") %>%
     collect() %>%
     count(batch)
   expect_equal(out_keywords$n[[1]], 4)
@@ -133,10 +133,10 @@ test_that("keywords_object2", {
     all = FALSE
   )
 
-  out_keywords <- filter(.tbl_keywords, batch > 1 & type == "object") %>%
+  out_keywords <- filter(gt.env$.tbl_keywords, batch > 1 & type == "object") %>%
     collect() %>%
     count(batch)
-  out_time <- filter(.tbl_time, batch > 1 & type == "object") %>%
+  out_time <- filter(gt.env$.tbl_time, batch > 1 & type == "object") %>%
     collect() %>%
     count(batch)
   expect_equal(nrow(out_keywords), 2)
@@ -169,10 +169,10 @@ test_that("keywords_object3", {
     all = FALSE
   )
 
-  out_keywords <- filter(.tbl_keywords, batch > 3 & type == "object") %>%
+  out_keywords <- filter(gt.env$.tbl_keywords, batch > 3 & type == "object") %>%
     collect() %>%
     count(batch)
-  out_time <- filter(.tbl_time, batch > 3 & type == "object") %>%
+  out_time <- filter(gt.env$.tbl_time, batch > 3 & type == "object") %>%
     collect() %>%
     count(batch)
   expect_equal(nrow(out_keywords), 2)

--- a/tests/testthat/test-locations.R
+++ b/tests/testthat/test-locations.R
@@ -19,9 +19,9 @@ test_that("add_loc1", {
     "Successfully created new location set dach \\(AT, DE, CH\\)\\."
   )
 
-  expect_error(
-    dach,
-    "object 'dach' not found"
+  expect_equal(
+    gt.env$dach,
+    NULL
   )
 
   expect_message(
@@ -34,7 +34,7 @@ test_that("add_loc1", {
   )
 
   expect_identical(
-    asia,
+    gt.env$asia,
     c("CN", "JP")
   )
 })
@@ -44,12 +44,12 @@ start_db()
 
 test_that("add_loc2", {
   expect_identical(
-    dach,
+    gt.env$dach,
     c("AT", "DE", "CH")
   )
 
   expect_identical(
-    asia,
+    gt.env$asia,
     c("CN", "JP")
   )
 })
@@ -65,12 +65,12 @@ add_object_keyword(
   time = "2010-01-01 2019-12-31"
 )
 
-dbWriteTable(globaltrends_db, "data_control", example_control, append = TRUE)
-dbWriteTable(globaltrends_db, "data_object", example_object, append = TRUE)
+dbWriteTable(gt.env$globaltrends_db, "data_control", example_control, append = TRUE)
+dbWriteTable(gt.env$globaltrends_db, "data_object", example_object, append = TRUE)
 
 # compute score ----------------------------------------------------------------
 test_that("compute_score1", {
-  out <- capture_messages(compute_score(object = 1, control = 1, locations = asia))
+  out <- capture_messages(compute_score(object = 1, control = 1, locations = gt.env$asia))
 
   expect_match(
     out,
@@ -83,7 +83,7 @@ test_that("compute_score1", {
     all = FALSE
   )
 
-  out <- tbl_score %>%
+  out <- gt.env$tbl_score %>%
     count(location) %>%
     collect()
 
@@ -99,9 +99,9 @@ test_that("compute_score1", {
 })
 
 test_that("compute_score2", {
-  compute_score(object = 1, control = 1, locations = countries)
+  compute_score(object = 1, control = 1, locations = gt.env$countries)
 
-  out <- tbl_score %>%
+  out <- gt.env$tbl_score %>%
     count(location) %>%
     collect()
 
@@ -125,7 +125,7 @@ test_that("compute_doi", {
     "Successfully computed DOI | control: 1 | object: 1 [1/1]"
   )
 
-  out <- tbl_doi %>%
+  out <- gt.env$tbl_doi %>%
     count(locations) %>%
     collect()
 
@@ -139,7 +139,7 @@ test_that("compute_doi", {
     c(1440, 1440)
   )
 
-  out <- tbl_doi %>%
+  out <- gt.env$tbl_doi %>%
     group_by(locations) %>%
     summarise(
       gini = mean(gini, na.rm = TRUE),
@@ -155,8 +155,8 @@ test_that("compute_doi", {
 
 # export score -----------------------------------------------------------------
 test_that("export_score", {
-  out1 <- export_score(location = asia)
-  out2 <- export_score(location = countries)
+  out1 <- export_score(location = gt.env$asia)
+  out2 <- export_score(location = gt.env$countries)
 
   expect_equal(
     unique(out1$location),

--- a/tests/testthat/test-plot_bar.R
+++ b/tests/testthat/test-plot_bar.R
@@ -10,7 +10,7 @@ initialize_db()
 start_db()
 
 # enter data -------------------------------------------------------------------
-dbWriteTable(globaltrends_db, "data_score", example_score, append = TRUE)
+dbWriteTable(gt.env$globaltrends_db, "data_score", example_score, append = TRUE)
 
 # plot_bar.exp_score ------------------------------------------------------------
 test_that("plot_bar.exp_score1", {

--- a/tests/testthat/test-plot_box.R
+++ b/tests/testthat/test-plot_box.R
@@ -10,8 +10,8 @@ initialize_db()
 start_db()
 
 # enter data -------------------------------------------------------------------
-dbWriteTable(globaltrends_db, "data_score", example_score, append = TRUE)
-dbWriteTable(globaltrends_db, "data_doi", example_doi, append = TRUE)
+dbWriteTable(gt.env$globaltrends_db, "data_score", example_score, append = TRUE)
+dbWriteTable(gt.env$globaltrends_db, "data_doi", example_doi, append = TRUE)
 
 # plot_box.exp_score ------------------------------------------------------------
 test_that("plot_box.exp_score1", {

--- a/tests/testthat/test-plot_map.R
+++ b/tests/testthat/test-plot_map.R
@@ -10,7 +10,7 @@ initialize_db()
 start_db()
 
 # enter data -------------------------------------------------------------------
-dbWriteTable(globaltrends_db, "data_score", example_score, append = TRUE)
+dbWriteTable(gt.env$globaltrends_db, "data_score", example_score, append = TRUE)
 
 # plot_map.exp_score ------------------------------------------------------------
 test_that("plot_map.exp_score1", {

--- a/tests/testthat/test-plot_ts.R
+++ b/tests/testthat/test-plot_ts.R
@@ -10,8 +10,8 @@ initialize_db()
 start_db()
 
 # enter data -------------------------------------------------------------------
-dbWriteTable(globaltrends_db, "data_score", example_score, append = TRUE)
-dbWriteTable(globaltrends_db, "data_doi", example_doi, append = TRUE)
+dbWriteTable(gt.env$globaltrends_db, "data_score", example_score, append = TRUE)
+dbWriteTable(gt.env$globaltrends_db, "data_doi", example_doi, append = TRUE)
 
 # plot_ts.exp_score ------------------------------------------------------------
 test_that("plot_ts.exp_score1", {

--- a/tests/testthat/test-plot_voi_doi.R
+++ b/tests/testthat/test-plot_voi_doi.R
@@ -9,8 +9,8 @@ initialize_db()
 start_db()
 
 # enter data -------------------------------------------------------------------
-dbWriteTable(globaltrends_db, "data_score", example_score, append = TRUE)
-dbWriteTable(globaltrends_db, "data_doi", example_doi, append = TRUE)
+dbWriteTable(gt.env$globaltrends_db, "data_score", example_score, append = TRUE)
+dbWriteTable(gt.env$globaltrends_db, "data_doi", example_doi, append = TRUE)
 
 # plot voi doi gini ------------------------------------------------------------
 test_that("plot_voi_doi-gini1", {

--- a/tests/testthat/test-synonyms.R
+++ b/tests/testthat/test-synonyms.R
@@ -42,31 +42,31 @@ test_that("add_synonyms1", {
     all = FALSE
   )
 
-  expect_equal(nrow(keyword_synonyms), 2)
+  expect_equal(nrow(gt.env$keyword_synonyms), 2)
 })
 
 # enter data -------------------------------------------------------------------
-data <- filter(example_control, batch == 1 & location %in% countries[1:3])
-dbWriteTable(globaltrends_db, "data_control", data, append = TRUE)
+data <- filter(example_control, batch == 1 & location %in% gt.env$countries[1:3])
+dbWriteTable(gt.env$globaltrends_db, "data_control", data, append = TRUE)
 data <- filter(
   example_object,
   batch_c == 1 & batch_o == 1 &
-    location %in% countries[1:2]
+    location %in% gt.env$countries[1:2]
 ) %>%
   mutate(batch_o = 1)
-dbWriteTable(globaltrends_db, "data_object", data, append = TRUE)
+dbWriteTable(gt.env$globaltrends_db, "data_object", data, append = TRUE)
 data <- filter(
   example_object,
   batch_c == 1 & batch_o == 2 &
-    location %in% countries[2:3]
+    location %in% gt.env$countries[2:3]
 ) %>%
   mutate(batch_o = 2)
-dbWriteTable(globaltrends_db, "data_object", data, append = TRUE)
+dbWriteTable(gt.env$globaltrends_db, "data_object", data, append = TRUE)
 
-compute_score(object = 1, locations = countries[1:2])
+compute_score(object = 1, locations = gt.env$countries[1:2])
 out1 <- export_score(keyword = "fc bayern")
 
-compute_score(object = 2, locations = countries[1:3])
+compute_score(object = 2, locations = gt.env$countries[1:3])
 out2 <- export_score(keyword = "fc bayern")
 
 # compare results --------------------------------------------------------------
@@ -83,14 +83,14 @@ test_that("keyword_score", {
 })
 
 test_that("keyword_synonym", {
-  out2_cn <- .tbl_score %>%
+  out2_cn <- gt.env$.tbl_score %>%
     filter(keyword == "bayern munich" & location == "CN") %>%
     collect() %>%
     summarise(synonym = mean(synonym), .groups = "drop")
 
   expect_equal(out2_cn$synonym, 2)
 
-  out2_jp <- .tbl_score %>%
+  out2_jp <- gt.env$.tbl_score %>%
     filter(keyword == "bayern munich" & location == "JP") %>%
     collect() %>%
     summarise(synonym = mean(synonym), .groups = "drop")


### PR DESCRIPTION
Write all data to environment `gt.env` instead of package namespace.